### PR TITLE
[fix] object-assign package is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@
 
 const filter = require('./lib/filter');
 
-var assign = require('object-assign');
-
-var config = hexo.config.slidehtml = assign({
+var config = hexo.config.slidehtml = Object.assign({
     titleMerge: true,
     horizontalSeparator: '^\\n---\\n',
     verticalSeparator: '^\\n--\\n',
@@ -17,4 +15,3 @@ var config = hexo.config.slidehtml = assign({
 hexo.extend.generator.register('slidehtml', require('./lib/generator'));
 hexo.extend.filter.register('before_post_render', filter.beforePostRender);
 hexo.extend.filter.register('after_post_render', filter.afterPostRender);
-


### PR DESCRIPTION
- [`Object.assign()`][1] has been supported since **Node.js 4.0.0**
- [Hexo 4.0.0][2] dropped the support of **Node.js 6.x**

So, use **Original API** directly, no 3th-party package is needed.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
[2]: https://hexo.io/news/2019/10/14/hexo-4-released/